### PR TITLE
remove unique GitHub ID restriction

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -9,5 +9,4 @@ set -eou pipefail
 
 nix flake check
 nix eval .#eval.module.config.thots "$@" >/dev/null
-nix eval .#eval.githubIdsAreUnique "$@" >/dev/null
 nix eval .#lib.testsPassed "$@" >/dev/null

--- a/flake.nix
+++ b/flake.nix
@@ -36,13 +36,8 @@
 
       lib = import ./lib.nix { inherit lib; };
 
-      # These can be evaluated with `nix eval` to run checks on the repo
-      eval = rec {
-        module = lib.evalModules { modules = [ self.nixosModules.thots ]; };
-        githubIds = map (thot: thot.githubId) (builtins.attrValues module.config.thots);
-        githubIdsAreUnique =
-          if githubIds == (lib.unique githubIds) then true else throw "Found duplicate GitHub IDs!";
-      };
+      # Use with `nix eval` to ensure the NixOS module is valid
+      eval.module = lib.evalModules { modules = [ self.nixosModules.thots ]; };
 
     };
 }


### PR DESCRIPTION
Originally I thought it would be best to enforce unique GitHub accounts for every users/{name}.nix file, but then I realized that people might want to manage multiple users (for example, I might want to manage my brother's config). I think this restriction should be removed.