### PR TITLE
remove 'sh' since a package for it does not exist

### DIFF
--- a/options.nix
+++ b/options.nix
@@ -50,7 +50,6 @@ lib: with lib; {
     type = types.enum [
       "bash"
       "fish"
-      "sh"
       "zsh"
     ];
   };


### PR DESCRIPTION
I updated my thothub flake input and then my system wouldn't build anymore because I was trying to set the shell for @masoniis to `pkgs.sh` which does not exist. Removing sh support. Just use bash man, it's basically the same thing.